### PR TITLE
fix(`CI`): Disable widget book for test job 🚀.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
         with:
           channel: ${{ env.flutter_channel }}
           flutter-version: ${{ env.flutter_version }}
+      
+      - name: Disable Widgetbook Generator for test
+        run: sed -i 's|widgetbook_generator|#widgetbook_generator|g' pubspec.yaml
 
       - name: Get Flutter dependencies
         run: flutter pub get .


### PR DESCRIPTION
We can skip widget_book generation when running tests since the Widget Book files are already generated and cached in the analyze step of CI.